### PR TITLE
BREAKING CHANGE: Upgrade Terraform AWS provider to v6

### DIFF
--- a/infra/terraform/deploy/providers.tf
+++ b/infra/terraform/deploy/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.7.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/infra/terraform/modules/acm-dns-cert/providers.tf
+++ b/infra/terraform/modules/acm-dns-cert/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = "~> 5.7.0"
+      version               = "~> 6.0"
       configuration_aliases = [aws.acm, aws.route53]
     }
   }

--- a/infra/terraform/modules/alias-route53/providers.tf
+++ b/infra/terraform/modules/alias-route53/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.7.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/infra/terraform/modules/api-gw-lambda/iam.tf
+++ b/infra/terraform/modules/api-gw-lambda/iam.tf
@@ -4,7 +4,7 @@ resource "aws_lambda_permission" "api_gw_invocation" {
   function_name = aws_lambda_function.lambda.function_name
   principal     = "apigateway.amazonaws.com"
 
-  source_arn = "${aws_api_gateway_deployment.proxy_api_gw.execution_arn}*"
+  source_arn = "${aws_api_gateway_stage.proxy_api_gw.execution_arn}*"
 }
 
 

--- a/infra/terraform/modules/api-gw-lambda/lambda.tf
+++ b/infra/terraform/modules/api-gw-lambda/lambda.tf
@@ -22,9 +22,9 @@ resource "null_resource" "update_lambda_origin_env" {
     command = <<-EOT
       aws lambda update-function-configuration \
       --profile ${var.aws_profile} \
-      --region ${data.aws_region.current.name} \
+      --region ${data.aws_region.current.region} \
       --function-name ${aws_lambda_function.lambda.function_name} \
-      --environment Variables={ORIGIN=${trim(replace(aws_api_gateway_deployment.proxy_api_gw.invoke_url, "/[^/]*$", "$1"), "/")}}
+      --environment Variables={ORIGIN=${trim(replace(aws_api_gateway_stage.proxy_api_gw.invoke_url, "/[^/]*$", "$1"), "/")}}
     EOT
   }
 

--- a/infra/terraform/modules/api-gw-lambda/outputs.tf
+++ b/infra/terraform/modules/api-gw-lambda/outputs.tf
@@ -30,7 +30,7 @@ output "api_created_date" {
 
 output "api_invoke_url" {
   description = "The invocation URL of the AWS API Gateway, pointing to the provided stage."
-  value       = aws_api_gateway_deployment.proxy_api_gw.invoke_url
+  value       = aws_api_gateway_stage.proxy_api_gw.invoke_url
 }
 
 output "api_key" {

--- a/infra/terraform/modules/api-gw-lambda/providers.tf
+++ b/infra/terraform/modules/api-gw-lambda/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.7.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/infra/terraform/modules/ssr-cf-dist/providers.tf
+++ b/infra/terraform/modules/ssr-cf-dist/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.7.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/infra/terraform/modules/static-asset-s3/providers.tf
+++ b/infra/terraform/modules/static-asset-s3/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.7.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "sveltekit-serverless-aws-template",
 	"description": "A moderately configurable template for getting a serverless SvelteKit application quickly set up on AWS.",
-	"version": "1.0.0",
+	"version": "2.0.0",
 	"type": "module",
 	"license": "MIT",
 	"private": true,


### PR DESCRIPTION
Bumps the Terraform AWS provider from ~> 5.7.0 to a more lenient ~> 6.0, across all of the IaC. To accommodate this, a few tweaks were made:
- `execution_arn` and `invoke_url` attributes for an API Gateway deployment have been moved to outputs of the stage itself, instead. The Terraform was adjusted to reflect this accordingly.
- `data.aws_region.current.name` is now deprecated. `data.aws_region.current.region` is now used instead.