### PR TITLE
fix: Manually decode error responses in the Lambda template

### DIFF
--- a/infra/lambda-template/lambda.js
+++ b/infra/lambda-template/lambda.js
@@ -6,8 +6,36 @@ import { handler as svelteHandler } from "./handler.js";
 const app = express();
 app.use(svelteHandler);
 
-const server = createServer(app);
+const binaryMimeTypes = [
+	'application/javascript',
+	'application/json',
+	'application/octet-stream',
+	'application/xml',
+	'font/eot',
+	'font/opentype',
+	'font/otf',
+	'image/jpeg',
+	'image/png',
+	'image/svg+xml',
+	'text/comma-separated-values',
+	'text/css',
+	'text/html',
+	'text/javascript',
+	'text/plain',
+	'text/text',
+	'text/xml'
+]
 
-export const handler = (event, context) => {
-	proxy(server, event, context);
+const server = createServer(app, null, binaryMimeTypes);
+
+export const handler = async (event, context) => {
+	console.log(JSON.stringify(event));
+	const res = await proxy(server, event, context, 'PROMISE').promise;
+
+	// Browsers won't decode 4xx and 5xx responses, so we need to decode them here
+	if (res.statusCode >= 400) {
+		res.body = Buffer.from(res.body, 'base64').toString('utf8');
+	}
+
+	return res;
 };


### PR DESCRIPTION
Something I never considered when building the `lambda-template` was that error responses will generally not be base64-decoded by the browser. Problem is, this Lambda will base64-encode everything it returns for your site, effectively. So your site might display properly, but your error pages will just look like HTML-wrapped base64-encoded garble.

So, this PR fixes that by checking the status code of the response, and if it's >=400, it'll decode it so the browser doesn't have to. That way, your error pages configured by `+error.svelte` and such will actually display properly, without affecting your normal happy-path content.